### PR TITLE
feat: define access rights

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@ SOFTWARE.
     <dependency>
       <groupId>io.surati.gap</groupId>
       <artifactId>admin-base</artifactId>
-      <version>0.2</version>
+      <version>0.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/io/surati/gap/admin/AdminModule.java
+++ b/src/main/java/io/surati/gap/admin/AdminModule.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 Surati
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+	
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.admin;
+
+import io.surati.gap.admin.api.Module;
+
+/**
+ * Admin module.
+ *
+ * @since 0.3
+ */
+public enum AdminModule implements Module {
+
+	ADMIN(
+		"Administration",
+		"Ce module permet de gérer les utilisateurs, leurs profils, les droits d'accès, etc."
+	);
+
+	static {
+		for (Module mod : AdminModule.values()) {
+			Module.VALUES.add(mod);
+			Module.BY_CODE.put(mod.code(), mod);
+		}
+	}
+
+	/**
+	 * Title of access.
+	 */
+	private String title;
+
+	/**
+	 * Description.
+	 */
+	private String description;
+
+	/**
+	 * Ctor.
+	 * @param title Title
+	 * @param description Description
+	 */
+	AdminModule(final String title, final String description) {
+		this.title = title;
+		this.description = description;
+	}
+	
+	/**
+	 * Get title.
+	 * @return Title
+	 */
+	@Override
+	public String title() {
+		return this.title;
+	}
+
+	/**
+	 * Get description.
+	 * @return Description
+	 */
+	@Override
+	public String description() {
+		return this.description;
+	}
+
+	/**
+	 * Get Code.
+	 * @return Code
+	 */
+	public String code() {
+		return this.name();
+	}
+	
+	@Override
+	public String toString() {
+		return this.title;
+	}
+}

--- a/src/main/java/io/surati/gap/admin/secure/AdminAccess.java
+++ b/src/main/java/io/surati/gap/admin/secure/AdminAccess.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 Surati
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+	
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.surati.gap.admin.secure;
+
+import io.surati.gap.admin.AdminModule;
+import io.surati.gap.admin.api.Access;
+import io.surati.gap.admin.api.Module;
+
+/**
+ * Access right for a user.
+ *
+ * @since 0.3
+ */
+public enum AdminAccess implements Access {
+
+	VISUALISER_UTILISATEURS("Visualiser les utilisateurs", ""),
+	CONFIGURER_UTILISATEURS("Configurer les utilisateurs", ""),
+	BLOQUER_UTILISATEURS("Bloquer les utilisateurs", ""),
+	CHANGER_MOT_DE_PASSE_UTILISATEURS("Changer le mot de passe d'un utilisateur", ""),
+	VISUALISER_PROFILS("Visualiser les profils utilisateur", ""),
+	CONFIGURER_PROFILS("Configurer les profils utilisateur", ""),
+	VISUALISER_INFO_ENTREPRISE("Visualiser les informations de l'entreprise", ""),
+	CONFIGURER_INFO_ENTREPRISE("Configurer les informations de l'entreprise", ""),
+	VISUALISER_LA_JOURNALISATION("Visualiser la journalisation", "");
+
+	static {
+		for (Access acs : AdminAccess.values()) {
+			Access.VALUES.add(acs);
+			Access.BY_CODE.put(acs.code(), acs);
+		}
+	}
+
+	/**
+	 * Title of access.
+	 */
+	private String title;
+
+	/**
+	 * Description.
+	 */
+	private String description;
+
+	/**
+	 * Ctor.
+	 * @param title Title
+	 * @param description Description
+	 */
+	AdminAccess(final String title, final String description) {
+		this.title = title;
+		this.description = description;
+	}
+	
+	/**
+	 * Get title.
+	 * @return Title
+	 */
+	@Override
+	public String title() {
+		return this.title;
+	}
+
+	/**
+	 * Get Code.
+	 * @return Code
+	 */
+	public String code() {
+		return this.name();
+	}
+
+	/**
+	 * Get description.
+	 * @return Code
+	 */
+	public String description() {
+		return this.description;
+	}
+
+	/**
+	 * Get module.
+	 * @return Module name
+	 */
+	public Module module() {
+		return AdminModule.ADMIN;
+	}
+	
+	@Override
+	public String toString() {
+		return this.title;
+	}
+}

--- a/src/main/java/io/surati/gap/admin/web/actions/TkAccessRightDelete.java
+++ b/src/main/java/io/surati/gap/admin/web/actions/TkAccessRightDelete.java
@@ -66,12 +66,12 @@ public final class TkAccessRightDelete implements Take {
 	@Override
 	public Response act(Request req) throws Exception {
 		final Log log = new RqLog(this.source, req);
-		final Access access = Access.valueOf(new RqHref.Smart(req).single("id"));
+		final Access access = Access.get(new RqHref.Smart(req).single("id"));
 		final Long profile_id = Long.parseLong(new RqHref.Smart(req).single("profile", "0"));
 		final Profile profile = new DbProfiles(this.source).get(profile_id);
 		final ProfileAccesses items = new DbProfileAccesses(this.source, profile);
 		items.remove(access);
-		log.info("Suppression de l'accès (%s) du profil (%s)", access.name(), profile.toString());
+		log.info("Suppression de l'accès (%s) du profil (%s)", access.code(), profile.toString());
 		return new RsForward(
 			new RsFlash(
 					String.format("Le droit d'accès du profil %s a été supprimé avec succès !", profile.name()),

--- a/src/main/java/io/surati/gap/admin/web/actions/TkAccessRightSave.java
+++ b/src/main/java/io/surati/gap/admin/web/actions/TkAccessRightSave.java
@@ -78,9 +78,9 @@ public final class TkAccessRightSave implements Take {
 			if(name.startsWith("access-")) {
 				final boolean ischecked = Boolean.parseBoolean(form.single(name));
 				if(ischecked) {
-					final Access access = Access.valueOf(name.split("-")[1].toUpperCase());
+					final Access access = Access.get(name.split("-")[1].toUpperCase());
 					items.add(access);
-					accadded.add(access.name());
+					accadded.add(access.code());
 				}
 			}
 		}

--- a/src/main/java/io/surati/gap/admin/web/pages/TkAccessRightAdd.java
+++ b/src/main/java/io/surati/gap/admin/web/pages/TkAccessRightAdd.java
@@ -71,7 +71,7 @@ public class TkAccessRightAdd implements Take  {
 		final Collection<Access> accesses = new LinkedList<>();
 		final Profile profile = new DbProfiles(this.source).get(profile_id);
 		
-		for (Access access : Access.values()) {
+		for (Access access : Access.VALUES) {
 			if(!profile.accesses().has(access)) {
 				accesses.add(access);
 			}


### PR DESCRIPTION
We introduced an enum `AdminAccess` implementing interface `Access` and we extract Admin modules rights as enum constants.

Fix: #51
